### PR TITLE
Add patch to disable timeout test on ARM

### DIFF
--- a/ubuntu/debian/patches/0001_arm_not_buildsamples_test.patch
+++ b/ubuntu/debian/patches/0001_arm_not_buildsamples_test.patch
@@ -1,0 +1,16 @@
+From: Jose Luis Rivero" <jrivero@osrfoundation.org>
+Subject: arm emulation is too slow to finish it on time
+
+diff --git a/test/integration/ExamplesBuild_TEST.cc b/test/integration/ExamplesBuild_TEST.cc
+index 8ae5f5e..a3245b8 100644
+--- a/test/integration/ExamplesBuild_TEST.cc
++++ b/test/integration/ExamplesBuild_TEST.cc
+@@ -373,7 +373,7 @@ void removeAll(const std::string &_path)
+ TEST(ExamplesBuild, Build)
+ {
+   // \todo(nkoenig) Fix windows.
+-#ifndef _WIN32
++#if defined(__arm__)
+   // Path to examples of the given type
+   std::string examplesDir = std::string(PROJECT_SOURCE_PATH) + "/examples/";
+ 

--- a/ubuntu/debian/patches/series
+++ b/ubuntu/debian/patches/series
@@ -1,1 +1,2 @@
 0004_fix_test_pose_zero_positive.patch
+0001_arm_not_buildsamples_test.patch


### PR DESCRIPTION
Failing test: https://build.osrfoundation.org/job/ign-math6-debbuilder/690/consoleFull#9932879636ea37b8d-a6d4-40ae-8431-d90c018842af
