### PR TITLE
Remove python package from Bionic

### DIFF
--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -16,7 +16,6 @@ Vcs-Browser: https://bitbucket.org/ignitionrobotics/ign_math-release
 Vcs-Hg: https://bitbucket.org/ignitionrobotics/ign_math-release
 Homepage: https://bitbucket.org/ignitionrobotics/ign_math
 XS-Ruby-Versions: all
-X-Python3-Version: >= 3.2
 
 Package: libignition-math6
 Architecture: any

--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -1,1 +1,101 @@
-../../ubuntu/debian/control
+Source: ignition-math6
+Standards-Version: 3.9.4
+Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
+Section: science
+Priority: extra
+Build-Depends: cmake,
+               debhelper (>= 11),
+               dh-python,
+               doxygen,
+               libeigen3-dev,
+               libignition-cmake2-dev,
+               python3,
+               python3-dev,
+               ruby-dev,
+               ruby-ronn,
+               swig
+Vcs-Browser: https://bitbucket.org/ignitionrobotics/ign_math-release
+Vcs-Hg: https://bitbucket.org/ignitionrobotics/ign_math-release
+Homepage: https://bitbucket.org/ignitionrobotics/ign_math
+XS-Ruby-Versions: all
+X-Python3-Version: >= 3.2
+
+Package: libignition-math6
+Architecture: any
+Section: libs
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Robotics Math Library - Shared library
+ A small, fast, and high performance math library. This library is a
+ self-contained set of classes and functions suitable for robot applications.
+ .
+ Ignition Robotics is a set of simple libraries that provide useful
+ functionality to bootstrap robot applications. The included libraries
+ encapsulate all the essentials, such as common math data types, console
+ logging, 3D mesh management, and asynchronous message passing.
+
+Package: libignition-math6-dev
+Architecture: any
+Section: libdevel
+Depends: libignition-math6 (= ${binary:Version}),
+         libignition-cmake2-dev,
+         ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Robotics Math Library - Development files
+ A small, fast, and high performance math library. This library is a
+ self-contained set of classes and functions suitable for robot applications.
+ .
+ Ignition Robotics is a set of simple libraries that provide useful
+ functionality to bootstrap robot applications. The included libraries
+ encapsulate all the essentials, such as common math data types, console
+ logging, 3D mesh management, and asynchronous message passing.
+
+Package: libignition-math6-eigen3-dev
+Architecture: any
+Section: libdevel
+Depends: libignition-math6-dev (= ${binary:Version}),
+         libeigen3-dev,
+         ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Robotics Math Library - Eigen3 Development files
+ A small, fast, and high performance math library. This library is a
+ self-contained set of classes and functions suitable for robot applications.
+ .
+ Ignition Robotics is a set of simple libraries that provide useful
+ functionality to bootstrap robot applications. The included libraries
+ encapsulate all the essentials, such as common math data types, console
+ logging, 3D mesh management, and asynchronous message passing.
+
+Package: ruby-ignition-math6
+Architecture: any
+XB-Ruby-Versions: ${ruby:Versions}
+Depends: ${misc:Depends},
+         ${ruby:Depends},
+         ${shlibs:Depends}
+Description: Ignition Robotics Math Library - Ruby bindings
+ A small, fast, and high performance math library. This library is a
+ self-contained set of classes and functions suitable for robot applications.
+ .
+ Ignition Robotics is a set of simple libraries that provide useful
+ functionality to bootstrap robot applications. The included libraries
+ encapsulate all the essentials, such as common math data types, console
+ logging, 3D mesh management, and asynchronous message passing.
+
+Package: libignition-math6-dbg
+Architecture: any
+Section: debug
+Priority: extra
+Depends:
+     libignition-math6 (= ${binary:Version}),
+     ${misc:Depends}
+Multi-Arch: same
+Description: Ignition Robotics Math Library - Debugging symbols
+ A small, fast, and high performance math library. This library is a
+ self-contained set of classes and functions suitable for robot applications.
+ .
+ Ignition Robotics is a set of simple libraries that provide useful
+ functionality to bootstrap robot applications. The included libraries
+ encapsulate all the essentials, such as common math data types, console
+ logging, 3D mesh management, and asynchronous message passing.
+

--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -5,12 +5,10 @@ Section: science
 Priority: extra
 Build-Depends: cmake,
                debhelper (>= 11),
-               dh-python,
                doxygen,
                libeigen3-dev,
                libignition-cmake2-dev,
                python3,
-               python3-dev,
                ruby-dev,
                ruby-ronn,
                swig

--- a/bionic/debian/python3-ignition-math6.install
+++ b/bionic/debian/python3-ignition-math6.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/python3-ignition-math.install

--- a/bionic/debian/rules
+++ b/bionic/debian/rules
@@ -1,1 +1,32 @@
-../../ubuntu/debian/rules
+#!/usr/bin/make -f
+
+DEB_HOST_ARCH := $(shell dpkg-architecture -qDEB_HOST_ARCH)
+
+.PHONY: override_dh_auto_configure \
+        override_dh_strip \
+        override_dh_install \
+        override_dh_auto_test
+
+%:
+	dh $@ --parallel
+
+override_dh_auto_configure:
+	dh_auto_configure -- \
+	    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+	    -DUSE_SYSTEM_PATHS_FOR_RUBY_INSTALLATION=ON
+
+override_dh_strip:
+	dh_strip -a --dbg-package=libignition-math6-dbg
+
+override_dh_install:
+	dh_install
+	# remove duplicate eigen files from mathx-dev.install regexp
+	cd debian/libignition-math6-eigen3-dev; find . -type f -exec rm -f ../libignition-math6-dev/{} \;
+	find debian/libignition-math6-dev -type d -empty -delete
+
+override_dh_auto_test:
+ifeq ($(DEB_HOST_ARCH),armhf)
+	true
+else
+	dh_auto_test $@ --no-parallel --buildsystem=cmake
+endif


### PR DESCRIPTION
Bionic has an old version of pybind11 [2.0.1](https://packages.ubuntu.com/source/bionic/pybind11), which isn't enough for our needs. Since the python packages are new and experimental, we're removing them from Bionic and targeting Focal onwards.

Buster has pybind11 [2.2.4](https://packages.debian.org/buster/python3-pybind11), so I expect it to work there.

The only difference between the Bionic control file and the rest is the lack of the python package:

```diff
$ diff -u ubuntu/debian/control bionic/debian/control 
--- ubuntu/debian/control	2022-01-13 14:31:44.061344295 -0800
+++ bionic/debian/control	2022-01-21 11:04:15.370993159 -0800
@@ -67,22 +67,6 @@
  encapsulate all the essentials, such as common math data types, console
  logging, 3D mesh management, and asynchronous message passing.
 
-Package: python3-ignition-math6
-Architecture: any
-Depends: ${misc:Depends},
-         python3-distutils,
-         python3-pybind11,
-         ${python3:Depends}
-Enhances: libignition-math6
-Description: Ignition Robotics Math Library - Python3 bindings
- A small, fast, and high performance math library. This library is a
- self-contained set of classes and functions suitable for robot applications.
- .
- Ignition Robotics is a set of simple libraries that provide useful
- functionality to bootstrap robot applications. The included libraries
- encapsulate all the essentials, such as common math data types, console
- logging, 3D mesh management, and asynchronous message passing.
-
 Package: ruby-ignition-math6
 Architecture: any
 XB-Ruby-Versions: ${ruby:Versions}
```

Test build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-math6-debbuilder&build=1324)](https://build.osrfoundation.org/job/ign-math6-debbuilder/1324/)