### PR TITLE
Script interfaces depend on -dev package

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -11,6 +11,8 @@ Build-Depends: cmake,
                libignition-cmake2-dev,
                python3,
                python3-dev,
+               python3-distutils,
+               python3-pybind11,
                ruby-dev,
                ruby-ronn,
                swig

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -70,6 +70,7 @@ Description: Ignition Robotics Math Library - Eigen3 Development files
 Package: python3-ignition-math6
 Architecture: any
 Depends: ${misc:Depends},
+         libignition-math6-dev (= ${binary:Version}),
          python3-distutils,
          python3-pybind11,
          ${python3:Depends}
@@ -87,6 +88,7 @@ Package: ruby-ignition-math6
 Architecture: any
 XB-Ruby-Versions: ${ruby:Versions}
 Depends: ${misc:Depends},
+         libignition-math6-dev (= ${binary:Version}),
          ${ruby:Depends},
          ${shlibs:Depends}
 Description: Ignition Robotics Math Library - Ruby bindings

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -69,10 +69,10 @@ Description: Ignition Robotics Math Library - Eigen3 Development files
 
 Package: python3-ignition-math6
 Architecture: any
-Depends: ${misc:Depends},
-         libignition-math6-dev (= ${binary:Version}),
+Depends: libignition-math6 (= ${binary:Version}),
          python3-distutils,
          python3-pybind11,
+         ${misc:Depends},
          ${python3:Depends}
 Enhances: libignition-math6
 Description: Ignition Robotics Math Library - Python3 bindings
@@ -87,8 +87,8 @@ Description: Ignition Robotics Math Library - Python3 bindings
 Package: ruby-ignition-math6
 Architecture: any
 XB-Ruby-Versions: ${ruby:Versions}
-Depends: ${misc:Depends},
-         libignition-math6-dev (= ${binary:Version}),
+Depends: libignition-math6 (= ${binary:Version}),
+         ${misc:Depends},
          ${ruby:Depends},
          ${shlibs:Depends}
 Description: Ignition Robotics Math Library - Ruby bindings


### PR DESCRIPTION
While trying the pre-release I ran into a little issue:

```
docker run --rm -ti ubuntu:focal
```

```
apt update
apt install -y lsb-release wget gnupg
sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list'
wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
apt-get update
apt install -y python3-ignition-math6
```

```
python3
>>> import ignition.math
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: libignition-math6.so.6: cannot open shared object file: No such file or directory
```

Installing `libignition-math6-dev` solves it. 

