### PR TITLE
Added patch to deal with PI precission in arm64

### DIFF
--- a/ubuntu/debian/patches/0002_PI_precision_in_arm64.patch
+++ b/ubuntu/debian/patches/0002_PI_precision_in_arm64.patch
@@ -1,0 +1,22 @@
+diff --git a/src/Helpers_TEST.cc b/src/Helpers_TEST.cc
+index a602f210..386d8188 100644
+--- a/src/Helpers_TEST.cc
++++ b/src/Helpers_TEST.cc
+@@ -1008,6 +1008,8 @@ TEST(HelpersTest, AppendToStream)
+   math::appendToStream(out, pi);
+ #ifdef _WIN32
+   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793");
++#elif  __aarch64__
++  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793238462643383279503");
+ #else
+   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239");
+ #endif
+@@ -1018,6 +1020,8 @@ TEST(HelpersTest, AppendToStream)
+   math::appendToStream(out, pi);
+ #ifdef _WIN32
+   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793 3.14");
++#elif  __aarch64__
++  EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793238462643383279503 3.14");
+ #else
+   EXPECT_EQ(out.str(), "0 456 0 3.14159 3.141592654 3.141592653589793239 3.14");
+ #endif

--- a/ubuntu/debian/patches/series
+++ b/ubuntu/debian/patches/series
@@ -1,2 +1,3 @@
 0004_fix_test_pose_zero_positive.patch
 0001_arm_not_buildsamples_test.patch
+0002_PI_precision_in_arm64.patch


### PR DESCRIPTION
Patch to deal with https://github.com/gazebosim/gz-math/issues/485. Not really a fix but more like a workaround.