### PR TITLE
Install gz/math/eigen* headers in eigen-dev pkg

### DIFF
--- a/ubuntu/debian/libignition-math-eigen3-dev.install
+++ b/ubuntu/debian/libignition-math-eigen3-dev.install
@@ -1,3 +1,5 @@
+usr/include/ignition/*/gz/math/eigen3/*
+usr/include/ignition/*/gz/math/eigen3.hh
 usr/include/ignition/*/ignition/math/eigen3/*
 usr/include/ignition/*/ignition/math/eigen3.hh
 usr/lib/*/pkgconfig/ignition-math?-eigen3.pc


### PR DESCRIPTION
We added `gz/*` headers in 6.13.0, but the `gz/math/eigen*` headers are installed in `libignition-math6-dev` instead of the `-eigen3-dev` package.

~~~
$ dpkg -l | grep math6-dev
ii  libignition-math6-dev:amd64                         6.13.0-1~focal                        amd64        Gazebo Math Library - Development files

$ dpkg -L libignition-math6-dev | grep eigen
/usr/include/ignition/math6/gz/math/eigen3
/usr/include/ignition/math6/gz/math/eigen3/Conversions.hh
/usr/include/ignition/math6/gz/math/eigen3/Util.hh
/usr/include/ignition/math6/gz/math/eigen3.hh
~~~

This ensures that all `eigen` headers are included in the `-eigen3-dev` package. The `rules` file has [special logic](https://github.com/gazebo-release/gz-math6-release/blob/main/ubuntu/debian/rules#L27-L29) to ensure that the `math6-dev` package doesn't try to install the same files as `math6-eigen3-dev`, so I think this is safe.

Test build with this branch that won't be uploaded: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-math6-debbuilder&build=1452)](https://build.osrfoundation.org/job/ign-math6-debbuilder/1452/) https://build.osrfoundation.org/job/ign-math6-debbuilder/1452/