### PR TITLE
Add Replaces, Breaks to fix broken -eigen3-dev

### DIFF
--- a/bionic/debian/changelog
+++ b/bionic/debian/changelog
@@ -1,3 +1,9 @@
+ignition-math6 (6.13.0-3~bionic) bionic; urgency=medium
+
+  * ignition-math6 6.13.0-3 release
+
+ -- Steve Peters <scpeters@openrobotics.org>  Sat, 15 Oct 2022 00:13:30 -0700
+
 ignition-math6 (6.13.0-2~bionic) bionic; urgency=medium
 
   * ignition-math6 6.13.0-2 release

--- a/bionic/debian/control
+++ b/bionic/debian/control
@@ -54,6 +54,8 @@ Section: libdevel
 Depends: libignition-math6-dev (= ${binary:Version}),
          libeigen3-dev,
          ${misc:Depends}
+Replaces: libignition-math6-dev (<< ${binary:Version})
+Breaks: libignition-math6-dev (<< ${binary:Version})
 Multi-Arch: same
 Description: Gazebo Math Library - Eigen3 Development files
  A small, fast, and high performance math library. This library is a

--- a/focal/debian/changelog
+++ b/focal/debian/changelog
@@ -1,3 +1,9 @@
+ignition-math6 (6.13.0-3~focal) focal; urgency=medium
+
+  * ignition-math6 6.13.0-3 release
+
+ -- Steve Peters <scpeters@openrobotics.org>  Sat, 15 Oct 2022 00:13:30 -0700
+
 ignition-math6 (6.13.0-2~focal) focal; urgency=medium
 
   * ignition-math6 6.13.0-2 release

--- a/focal/debian/control
+++ b/focal/debian/control
@@ -61,8 +61,10 @@ Section: libdevel
 Depends: libignition-math6-dev (= ${binary:Version}),
          libeigen3-dev,
          ${misc:Depends}
-Replaces: libignition-math-dev (<< 6.0.0~)
-Breaks: libignition-math-dev (<< 6.0.0~)
+Replaces: libignition-math-dev (<< ${binary:Version}),
+          libignition-math6-dev (<< ${binary:Version})
+Breaks: libignition-math-dev (<< ${binary:Version}),
+        libignition-math6-dev (<< ${binary:Version})
 Multi-Arch: same
 Description: Gazebo Math Library - Eigen3 Development files
  A small, fast, and high performance math library. This library is a

--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,3 +1,9 @@
+ignition-math6 (6.13.0-3~jammy) jammy; urgency=medium
+
+  * ignition-math6 6.13.0-3 release
+
+ -- Steve Peters <scpeters@openrobotics.org>  Sat, 15 Oct 2022 00:13:30 -0700
+
 ignition-math6 (6.13.0-2~jammy) jammy; urgency=medium
 
   * ignition-math6 6.13.0-2 release

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -65,8 +65,10 @@ Section: libdevel
 Depends: libignition-math6-dev (= ${binary:Version}),
          libeigen3-dev,
          ${misc:Depends}
-Replaces: libignition-math-dev (<< ${binary:Version})
-Breaks: libignition-math-dev (<< ${binary:Version})
+Replaces: libignition-math-dev (<< ${binary:Version}),
+          libignition-math6-dev (<< ${binary:Version})
+Breaks: libignition-math-dev (<< ${binary:Version}),
+        libignition-math6-dev (<< ${binary:Version})
 Multi-Arch: same
 Description: Gazebo Math Library - Eigen3 Development files
  A small, fast, and high performance math library. This library is a


### PR DESCRIPTION
Some header files were moved from -math6-dev to
-math6-eigen3-dev recently, but I've noticed some trouble
upgrading. This adds Breaks and Replaces statements
to try to ease upgrading.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_gazebo-ci_asan-ign-gazebo6-focal-amd64&build=24)](https://build.osrfoundation.org/job/ignition_gazebo-ci_asan-ign-gazebo6-focal-amd64/24/) https://build.osrfoundation.org/job/ignition_gazebo-ci_asan-ign-gazebo6-focal-amd64/24/

~~~
Unpacking libignition-math6-eigen3-dev:amd64 (6.13.0-2~focal) over (6.13.0-1~focal) ...
dpkg: error processing archive /tmp/apt-dpkg-install-0BF65M/20-libignition-math6-eigen3-dev_6.13.0-2~focal_amd64.deb (--unpack):
 trying to overwrite '/usr/include/ignition/math6/gz/math/eigen3/Conversions.hh', which is also in package libignition-math6-dev:amd64 6.13.0-1~focal
~~~